### PR TITLE
Updates location and addresses Bill's comments

### DIFF
--- a/basic-remote-attestation.tree
+++ b/basic-remote-attestation.tree
@@ -49,6 +49,7 @@ module: basic-remote-attestation
     |  |  |     +---w COSE_Algorithm-value?   int32
     |  |  +---w tpm_name?                     string
     |  |  +---w tpm-physical-index?           int32 {ietfhw:entity-mib}?
+    |  |  +---w certificate-name?             string
     |  +--ro output
     |     +--ro attestation-certificates* [tpm_name]
     |        +--ro tpm_name                   string
@@ -56,7 +57,8 @@ module: basic-remote-attestation
     |        +--ro up-time?                   uint32
     |        +--ro node-name?                 string
     |        +--ro node-physical-index?       int32 {ietfhw:entity-mib}?
-    |        +--ro attestation-certificate?   binary
+    |        +--ro certificate-name?          string
+    |        +--ro attestation-certificate?   ietfct:end-entity-cert-cms
     |        +--ro (key-identifier)?
     |           +--:(public-key)
     |           |  +--ro pub-key-id?          binary
@@ -71,7 +73,9 @@ module: basic-remote-attestation
        |  |     +--:(last-entry)
        |  |     |  +---w last-entry-value?   binary
        |  |     +--:(index)
-       |  |        +---w index-number?       uint64
+       |  |     |  +---w index-number?       uint64
+       |  |     +--:(timestamp)
+       |  |        +---w timestamp?          yang:date-and-time
        |  +---w measurement-log-type    identityref
        |  +---w pcr-list* []
        |  |  +---w pcr
@@ -81,7 +85,7 @@ module: basic-remote-attestation
        |  |        |  +---w tcg-hash-algo-id?       uint16
        |  |        +--:(ietf)
        |  |           +---w ietf-ni-hash-algo-id?   uint8
-       |  +---w chunk-size?             uint64
+       |  +---w log-entry-quantity?     uint16
        +--ro output
           +--ro system-event-logs
              +--ro node-data* [node-name]

--- a/basic-remote-attestation.tree
+++ b/basic-remote-attestation.tree
@@ -26,11 +26,11 @@ module: basic-remote-attestation
     |  |  |     |  +---w pub-key-id?             binary
     |  |  |     +--:(uuid)
     |  |  |        +---w uuid-value?             binary
-    |  |  +---w name?                         string
+    |  |  +---w tpm_name?                     string
     |  |  +---w tpm-physical-index?           int32 {ietfhw:entity-mib}?
     |  +--ro output
-    |     +--ro tpm2-attestation-response* [name]
-    |        +--ro name                   string
+    |     +--ro tpm2-attestation-response* [tpm_name]
+    |        +--ro tpm_name               string
     |        +--ro tpm-physical-index?    int32 {ietfhw:entity-mib}?
     |        +--ro up-time?               uint32
     |        +--ro node-name?             string
@@ -47,11 +47,11 @@ module: basic-remote-attestation
     |  |  |  |  +---w TPM_ALG_ID-value?       uint16
     |  |  |  +--:(COSE_Algorithm)
     |  |  |     +---w COSE_Algorithm-value?   int32
-    |  |  +---w name?                         string
+    |  |  +---w tpm_name?                     string
     |  |  +---w tpm-physical-index?           int32 {ietfhw:entity-mib}?
     |  +--ro output
-    |     +--ro attestation-certificates* [name]
-    |        +--ro name                       string
+    |     +--ro attestation-certificates* [tpm_name]
+    |        +--ro tpm_name                   string
     |        +--ro tpm-physical-index?        int32 {ietfhw:entity-mib}?
     |        +--ro up-time?                   uint32
     |        +--ro node-name?                 string
@@ -88,8 +88,8 @@ module: basic-remote-attestation
                 +--ro node-name              string
                 +--ro node-physical-index?   int32 {ietfhw:entity-mib}?
                 +--ro up-time?               uint32
-                +--ro tpm-updated* [name]
-                |  +--ro name                  string
+                +--ro tpm-updated* [tpm_name]
+                |  +--ro tpm_name              string
                 |  +--ro tpm-physical-index?   int32 {ietfhw:entity-mib}?
                 +--ro log-result
                    +--ro (log-type)

--- a/basic-remote-attestation.tree
+++ b/basic-remote-attestation.tree
@@ -4,7 +4,7 @@ module: basic-remote-attestation
      +--rw endorsement-certificate    binary
 
   rpcs:
-    +---x tpm2-challenge-repsonse-attestation
+    +---x tpm2-challenge-response-attestation
     |  +---w input
     |  |  +---w tpm2-attestation-challenge
     |  |  |  +---w pcr-list* []
@@ -26,37 +26,36 @@ module: basic-remote-attestation
     |  |  |     |  +---w pub-key-id?             binary
     |  |  |     +--:(uuid)
     |  |  |        +---w uuid-value?             binary
-    |  |  +---w location?                     string
+    |  |  +---w name?                         string
+    |  |  +---w tpm-physical-index?           int32 {ietfhw:entity-mib}?
     |  +--ro output
-    |     +--ro tpm2-attestation-response* [location]
-    |        +--ro location          string
-    |        +--ro up-time?          uint32
+    |     +--ro tpm2-attestation-response* [name]
+    |        +--ro name                   string
+    |        +--ro tpm-physical-index?    int32 {ietfhw:entity-mib}?
+    |        +--ro up-time?               uint32
+    |        +--ro node-name?             string
+    |        +--ro node-physical-index?   int32 {ietfhw:entity-mib}?
     |        +--ro tpms-attest
     |        |  +--ro pcrdigest?            binary
-    |        |  +--ro pcrdigest-length?     uint32
     |        |  +--ro tpms-attest-result?   binary
-    |        +--ro tpmt-signature?   binary
+    |        +--ro tpmt-signature?        binary
     +---x basic-trust-establishment
     |  +---w input
     |  |  +---w nonce-value                   binary
-    |  |  +---w pcr-list* []
-    |  |  |  +---w pcr
-    |  |  |     +---w pcr-numbers*                  uint8
-    |  |  |     +---w (algo-registry-type)
-    |  |  |        +--:(tcg)
-    |  |  |        |  +---w tcg-hash-algo-id?       uint16
-    |  |  |        +--:(ietf)
-    |  |  |           +---w ietf-ni-hash-algo-id?   uint8
     |  |  +---w (signature-identifier-type)
     |  |  |  +--:(TPM_ALG_ID)
     |  |  |  |  +---w TPM_ALG_ID-value?       uint16
     |  |  |  +--:(COSE_Algorithm)
     |  |  |     +---w COSE_Algorithm-value?   int32
-    |  |  +---w location?                     string
+    |  |  +---w name?                         string
+    |  |  +---w tpm-physical-index?           int32 {ietfhw:entity-mib}?
     |  +--ro output
-    |     +--ro attestation-certificates* [location]
-    |        +--ro location                   string
+    |     +--ro attestation-certificates* [name]
+    |        +--ro name                       string
+    |        +--ro tpm-physical-index?        int32 {ietfhw:entity-mib}?
     |        +--ro up-time?                   uint32
+    |        +--ro node-name?                 string
+    |        +--ro node-physical-index?       int32 {ietfhw:entity-mib}?
     |        +--ro attestation-certificate?   binary
     |        +--ro (key-identifier)?
     |           +--:(public-key)
@@ -65,8 +64,9 @@ module: basic-remote-attestation
     |              +--ro uuid-value?          binary
     +---x log-retrieval
        +---w input
-       |  +---w log-selector* [location]
-       |  |  +---w location                  string
+       |  +---w log-selector* [node-name]
+       |  |  +---w node-name                 string
+       |  |  +---w node-physical-index?      int32 {ietfhw:entity-mib}?
        |  |  +---w (index-type)?
        |  |     +--:(last-entry)
        |  |     |  +---w last-entry-value?   binary
@@ -82,12 +82,15 @@ module: basic-remote-attestation
        |  |        +--:(ietf)
        |  |           +---w ietf-ni-hash-algo-id?   uint8
        |  +---w chunk-size?             uint64
-       |  +---w location?               string
        +--ro output
           +--ro system-event-logs
-             +--ro node-data* [location]
-                +--ro location      string
-                +--ro up-time?      uint32
+             +--ro node-data* [node-name]
+                +--ro node-name              string
+                +--ro node-physical-index?   int32 {ietfhw:entity-mib}?
+                +--ro up-time?               uint32
+                +--ro tpm-updated* [name]
+                |  +--ro name                  string
+                |  +--ro tpm-physical-index?   int32 {ietfhw:entity-mib}?
                 +--ro log-result
                    +--ro (log-type)
                       +--:(bios)

--- a/basic-remote-attestation.yang
+++ b/basic-remote-attestation.yang
@@ -197,7 +197,7 @@ module basic-remote-attestation {
    description
      "In a system with multiple-TPMs get the data from a specific TPM
       identified by the name and physical-index.";
-   leaf name {
+   leaf tpm_name {
       type string;
       description
       "Name of the TPM or All";
@@ -448,7 +448,7 @@ grouping boot-event-log {
     }
     output {
       list tpm2-attestation-response {
-        key name;
+        key tpm_name;
         description
           "The binary output of TPM2b_Quote. An TPMS_ATTEST structure
           including a length, encapsulated in a signature";
@@ -490,7 +490,7 @@ grouping boot-event-log {
     }
     output {
     list attestation-certificates {
-      key name;
+      key tpm_name;
       description
         "Attestation Certificate data from a TPM identified by the TPM name";
       uses tpm-name;
@@ -562,7 +562,7 @@ grouping boot-event-log {
            uses compute-node;
 	   uses node-uptime;
 	   list tpm-updated {
-	     key name;
+	     key tpm_name;
 	     description
 	     "TPM these events may have recorded data in";
 	     uses tpm-name;

--- a/basic-remote-attestation.yang
+++ b/basic-remote-attestation.yang
@@ -544,7 +544,7 @@ grouping boot-event-log {
               "The last entry of the log already retrieved.";
             leaf last-entry-value {
               description
-              "Content of an 'event-string' which matches 1:1 with a 
+              "Content of an log event which matches 1:1 with a 
               unique event record contained within the log.  Log 
               entries subsequent to this will be passed to the 
               requestor.  Note: if log entry values are not unique, 

--- a/basic-remote-attestation.yang
+++ b/basic-remote-attestation.yang
@@ -1,6 +1,11 @@
 module basic-remote-attestation {
   namespace "urn:ietf:params:xml:ns:yang:brat";
   prefix "yang-brat";
+
+  import ietf-hardware {
+      prefix ietfhw;
+  }
+
   organization
    "Fraunhofer SIT";
   contact
@@ -188,17 +193,47 @@ module basic-remote-attestation {
     }
   }
   
- grouping node-location {
+ grouping tpm-name {
    description
-     "In a distributed system get the data from a specific node
-      identified by the location. If this field is not specified
-      data associated with each node forming the system will be
-      returned.";
-   leaf location {
+     "In a system with multiple-TPMs get the data from a specific TPM
+      identified by the name and physical-index.";
+   leaf name {
       type string;
       description
-      "Location of the node or All";
+      "Name of the TPM or All";
    }
+   leaf tpm-physical-index {
+       if-feature ietfhw:entity-mib;
+       type int32 {
+            range "1..2147483647";
+       }
+       config false;
+       description
+            "The entPhysicalIndex for the TPM.";
+        reference
+            "RFC 6933: Entity MIB (Version 4) - entPhysicalIndex";
+     }
+ }
+ grouping compute-node {
+   description
+     "In a distributed system with multiple compute nodes
+      this is the node identified by name and physical-index.";
+   leaf node-name {
+      type string;
+      description
+      "Name of the compute node or All";
+   }
+   leaf node-physical-index {
+       if-feature ietfhw:entity-mib;
+       type int32 {
+            range "1..2147483647";
+       }
+       config false;
+       description
+            "The entPhysicalIndex for the compute node.";
+        reference
+            "RFC 6933: Entity MIB (Version 4) - entPhysicalIndex";
+     }
  }
 
  grouping node-uptime {
@@ -391,7 +426,7 @@ grouping boot-event-log {
   }
 
 
-  rpc tpm2-challenge-repsonse-attestation {
+  rpc tpm2-challenge-response-attestation {
     description
       "This RPC accepts the input for TSS commands of the managed device.
       ComponentIndex from the hardware manager YANG module to refer to 
@@ -409,16 +444,17 @@ grouping boot-event-log {
         uses signature-scheme;
         uses attestation-key-identifier;
       }
-      uses node-location;
+      uses tpm-name;
     }
     output {
       list tpm2-attestation-response {
-        key location;
+        key name;
         description
           "The binary output of TPM2b_Quote. An TPMS_ATTEST structure
           including a length, encapsulated in a signature";
-	uses node-location;
+	uses tpm-name;
 	uses node-uptime;
+	uses compute-node;
         container tpms-attest {
           description
             "A composite of value and length and list of selected
@@ -427,11 +463,6 @@ grouping boot-event-log {
             description
               "split out value of TPMS_QUOTE_INFO for convenience";
             type binary;
-          }
-          leaf pcrdigest-length {
-            description
-              "split out length of digest for convenience";
-            type uint32;
           }
           leaf tpms-attest-result {
             description
@@ -454,18 +485,17 @@ grouping boot-event-log {
       in TPM_Quote commands, an attestation certificate.";
     input {
       uses nonce;
-      uses pcr-selector;
       uses signature-scheme;
-      uses node-location;
+      uses tpm-name;
     }
     output {
     list attestation-certificates {
-      key location;
+      key name;
       description
-        "Attestation Certificate data of a node in a distributed system
-        identified by the location";
-      uses node-location;
+        "Attestation Certificate data from a TPM identified by the TPM name";
+      uses tpm-name;
       uses node-uptime;
+      uses compute-node;
       leaf attestation-certificate {
         description
           "An individual signed public attestation according to requested
@@ -485,10 +515,10 @@ grouping boot-event-log {
       augmented.";
     input {
       list log-selector {
-        key location;
+        key node-name;
         description
 	 "Selection of log entries to be reported.";
-	uses node-location;
+	uses compute-node;
         choice index-type {
           description
             "Last-line or index.";
@@ -519,19 +549,24 @@ grouping boot-event-log {
          "The number of log entries to be returned. If omitted, it means all of them.";
         type uint64;
       }
-      uses node-location;
     } 
     output {
       container system-event-logs {
          description
 	 "The requested data of the measurement event logs";
          list node-data {
-           key location;
+           key node-name;
            description
            "Event logs of a node in a distributed system
-            identified by the location";
-           uses node-location;
+            identified by the node name";
+           uses compute-node;
 	   uses node-uptime;
+	   list tpm-updated {
+	     key name;
+	     description
+	     "TPM these events may have recorded data in";
+	     uses tpm-name;
+	   }
            container log-result {
              description
              "The requested entries of the corresponding log.";

--- a/basic-remote-attestation.yang
+++ b/basic-remote-attestation.yang
@@ -1,11 +1,17 @@
 module basic-remote-attestation {
   namespace "urn:ietf:params:xml:ns:yang:brat";
   prefix "yang-brat";
-
+  
+  import ietf-yang-types {
+    prefix yang;
+  }
   import ietf-hardware {
       prefix ietfhw;
   }
-
+  import ietf-crypto-types {
+      prefix ietfct;
+  }
+  
   organization
    "Fraunhofer SIT";
   contact
@@ -125,7 +131,7 @@ module basic-remote-attestation {
       container pcr {
         description
           "The composite of a PCR number and corresponding bank numbers.";
-        leaf-list pcr-numbers {
+        leaf-list pcr-index {
            description
              "The numbers of the PCRs that are associated with
              the created key. At the moment the highest number is 32";
@@ -395,6 +401,7 @@ grouping boot-event-log {
       mandatory true;
       description
         "Event log type determines the event logs content.";
+
       case bios {
         description
           "BIOS/UEFI event logs";
@@ -487,6 +494,11 @@ grouping boot-event-log {
       uses nonce;
       uses signature-scheme;
       uses tpm-name;
+      leaf certificate-name {
+         type string;
+         description
+         "An arbitrary name for the identity certificate chain requested.";
+      }
     }
     output {
     list attestation-certificates {
@@ -496,11 +508,15 @@ grouping boot-event-log {
       uses tpm-name;
       uses node-uptime;
       uses compute-node;
+      leaf certificate-name {
+         type string;
+         description
+         "An arbitrary name for this identity certificate or certificate chain.";
+      }      
       leaf attestation-certificate {
         description
-          "An individual signed public attestation according to requested
-          capabilities.";
-        type binary;
+          "The binary signed certificate chain data for this identity certificate.";
+        type ietfct:end-entity-cert-cms;
       }
       uses attestation-key-identifier;
     }
@@ -521,33 +537,52 @@ grouping boot-event-log {
 	uses compute-node;
         choice index-type {
           description
-            "Last-line or index.";
+             "Last log entry received, log index number, or timestamp.";
+
           case last-entry {
             description
-              "The last entry of the log already retrieved";
+              "The last entry of the log already retrieved.";
             leaf last-entry-value {
               description
-                "Content of the last entry requested.";
-              type binary;
+              "Content of an 'event-string' which matches 1:1 with a 
+              unique event record contained within the log.  Log 
+              entries subsequent to this will be passed to the 
+              requestor.  Note: if log entry values are not unique, 
+              this MUST return an error.";
+	      type binary;
             }
           }
           case index {
-            description
-              "Numeric index of the last log entry retrieved.";
+	    description
+              "Numeric index of the last log entry retrieved, or zero.";
             leaf index-number {
               description
-                "The numeric index number";
+              "The numeric index number of a log entry.  Zero means 
+              to start at the beginning of the log.   Entries
+              subsequent to this will be passed to the 
+              requestor.";
               type uint64;
             }
+          }
+          case timestamp {
+            leaf timestamp {
+              type yang:date-and-time;
+              description
+                "Timestamp from which to start the extraction.  The next
+                log entry subsequent to this timestamp is to be sent.";
+            }
+            description
+              "Timestamp from which to start the extraction.";
           }
         }
       }
       uses log-identifier;
       uses pcr-selection;
-      leaf chunk-size {
+      leaf log-entry-quantity {
+        type uint16;
         description
-         "The number of log entries to be returned. If omitted, it means all of them.";
-        type uint64;
+         "The number of log entries to be returned. If omitted, it 
+         means all of them.";
       }
     } 
     output {

--- a/draft-birkholz-yang-basic-remote-attestation.md
+++ b/draft-birkholz-yang-basic-remote-attestation.md
@@ -58,7 +58,8 @@ author:
   region: Massachusetts
 normative:
   RFC2119:
-
+  I-D.ietf-netconf-crypto-types:
+  
 informative:
   I-D.birkholz-attestation-terminology: rats
 


### PR DESCRIPTION
This is following up on the discussion b/n Henk, Eric, Bill, Shwetha to:
1. Replace location of a node / TPM within a composite system with tpm-name/node-name and Physical-index of the component (compute node or tpm-name) as specified in EntityMIB.
2. basic trust establishment is updated to request a specific identity cert chain and return signed identity cert chain.
3. Removed reference to PCR selector in basic trust establishment
4. Added timestamp in log-retrieval
5. Renamed chunk-size in log-retrieval request to  log-entry-quantity 
6. Imported ietf-crypto-types for the signed certificate typedef
7.  Imported ietf-hardware for EntityMIB physical-index reference
ietf-crypto-types and 
A few more nits.